### PR TITLE
automated-converter/converter.sh: Wrap $@ in double quotes

### DIFF
--- a/automated-converter/converter.sh
+++ b/automated-converter/converter.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 # note: do update this script by setting the correct path to whatever blender instance you have installed
-"/path/to/blender" -b -P "IOmanager.py" ${@}
+"/path/to/blender" -b -P "IOmanager.py" "${@}"


### PR DESCRIPTION
Fix [SC2068](https://github.com/koalaman/shellcheck/wiki/SC2068)

If `${@}` is not wrapped in double quotes, there is a problem with parsing arguments, so changed.
