### PR TITLE
Clean up importer UI

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -95,13 +95,13 @@ class ImportBmd(Operator, ImportHelper):
     # List of operator properties, the attributes will be assigned
     # to the class instance from the operator settings before calling.
 
-    import_anims : BoolProperty(
+    import_anims: BoolProperty(
         name="Import animations",
         description="",
         default=True
     )
     
-    import_anims_type : EnumProperty(
+    import_anims_type: EnumProperty(
         name="Animation Mode",
         description="If you choose to import animations, you can choose to chain them or put them in individual actions",
         items=(('SEPARATE', "Separate", 'Animations will be imported into individual actions inside an NLA Track'),
@@ -110,7 +110,7 @@ class ImportBmd(Operator, ImportHelper):
         default='SEPARATE'
     )
 
-    use_nodes : BoolProperty(
+    use_nodes: BoolProperty(
         name="Use complete materials",
         description="Use complete GLSL materials converted into nodes."
                     "More precise, but impossible to export for now.",
@@ -270,7 +270,8 @@ class BMD_PT_import_animation(bpy.types.Panel):
     def draw_header(self, context):
         sfile = context.space_data
         operator = sfile.active_operator
-
+        
+        self.layout.enabled = getattr(operator, 'nat_bn') != True
         self.layout.prop(operator, "import_anims", text="")
         
     def draw(self, context):
@@ -281,7 +282,7 @@ class BMD_PT_import_animation(bpy.types.Panel):
         sfile = context.space_data
         operator = sfile.active_operator
         
-        layout.enabled = operator.import_anims
+        layout.enabled = operator.import_anims and not operator.nat_bn
         layout.prop(operator, 'import_anims_type')
 
 

--- a/common.py
+++ b/common.py
@@ -176,13 +176,13 @@ def dedup_lines(string):
 
 
 class Prog_params:
-    def __init__(self, filename, boneThickness, frc_cr_bn, sv_anim,
+    def __init__(self, filename, boneThickness, frc_cr_bn, import_anims, import_anims_type,
                  tx_pck, ic_sc, imtype, dvg=False, nat_bn=False, use_nodes=False, val_msh=False, paranoia=False, no_rot_cv=False):
         self.filename = filename
         self.boneThickness = boneThickness
         self.forceCreateBones = frc_cr_bn
-        self.loadAnimations = sv_anim != 'DONT' and not nat_bn
-        self.animationType = sv_anim if self.loadAnimations else 'DONT'
+        self.loadAnimations = import_anims and not nat_bn
+        self.animationType = import_anims_type
         self.naturalBones = nat_bn
         self.packTextures = tx_pck
         self.includeScaling = ic_sc


### PR DESCRIPTION
This PR brings the importer options UI into line with other Blender importers. Besides the UI itself, the animation importer options have been slightly changed. Whether animations are imported is now a checkbox, and the import mode dropdown now only contains "separate" and "chained". Some default values for the properties have also been changed.